### PR TITLE
Dev 1992 approval job

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -41,19 +41,14 @@ class Api {
    */
   constructor(options = {}) {
     const settings = Object.assign({}, Api.defaults, options);
-    if (options.accessToken) {
-      this.accessToken = options.accessToken;
-      settings.headers["Authorization"] = `Bearer ${options.accessToken}`;
-    }
     this.client = axios.create({
       baseURL: settings.apiUrl.replace(/\/$/, ""),
       timeout: settings.timeout,
       headers: settings.headers,
     });
-    this.client.get(`/auth/me`).then((response) => {
-      this.clientEmail = response.data?.email;
-      this.clientId = response.data?._id;
-    })
+    if (options.accessToken) {
+      this.setAccessToken(options.accessToken)
+    }
   }
 
   setAccessToken(accessToken) {

--- a/src/Api.js
+++ b/src/Api.js
@@ -50,11 +50,19 @@ class Api {
       timeout: settings.timeout,
       headers: settings.headers,
     });
+    this.client.get(`/auth/me`).then((response) => {
+      this.clientEmail = response.data?.email;
+      this.clientId = response.data?._id;
+    })
   }
 
   setAccessToken(accessToken) {
     this.accessToken = accessToken;
     this.client.defaults.headers["Authorization"] = `Bearer ${accessToken}`;
+    this.client.get(`/auth/me`).then((response) => {
+      this.clientEmail = response.data?.email;
+      this.clientId = response.data?._id;
+    })
   }
 
   revokeAccessToken() {

--- a/src/App.js
+++ b/src/App.js
@@ -28,6 +28,8 @@ export function withAppContext(Component) {
   return WrappedComponent;
 }
 
+
+
 withAppContext.propTypes = {
   services: PropTypes.object,
   authenticated: PropTypes.bool,
@@ -74,8 +76,8 @@ class App extends Component {
   async componentDidMount() {
     await this.fetchData();
     const params = new URLSearchParams(window.location.search);
-    if (params.get("access_token")) {
-      this.state.setAccessToken(params.get("access_token"));
+    if(params.get('access_token')){
+       this.state.setAccessToken(params.get('access_token'));
     }
   }
 
@@ -97,7 +99,7 @@ class App extends Component {
       <BrowserRouter>
         <AppContext.Provider value={this.state}>
           {services && (
-            <Layout hasSider style={{ minHeight: "100vh" }}>
+            <Layout hasSider style={{ minHeight: "100vh"}}>
               <AdminMenu services={services} />
               <Layout>
                 <Routes>

--- a/src/App.js
+++ b/src/App.js
@@ -28,8 +28,6 @@ export function withAppContext(Component) {
   return WrappedComponent;
 }
 
-
-
 withAppContext.propTypes = {
   services: PropTypes.object,
   authenticated: PropTypes.bool,
@@ -76,8 +74,8 @@ class App extends Component {
   async componentDidMount() {
     await this.fetchData();
     const params = new URLSearchParams(window.location.search);
-    if(params.get('access_token')){
-       this.state.setAccessToken(params.get('access_token'));
+    if (params.get("access_token")) {
+      this.state.setAccessToken(params.get("access_token"));
     }
   }
 
@@ -99,7 +97,7 @@ class App extends Component {
       <BrowserRouter>
         <AppContext.Provider value={this.state}>
           {services && (
-            <Layout hasSider style={{ minHeight: "100vh"}}>
+            <Layout hasSider style={{ minHeight: "100vh" }}>
               <AdminMenu services={services} />
               <Layout>
                 <Routes>

--- a/src/components/AutomatorService/AutomatorJob.js
+++ b/src/components/AutomatorService/AutomatorJob.js
@@ -76,11 +76,11 @@ class AutomatorJob extends Component {
             <Button
               danger
               style={{ borderColor: "green", color: "green" }}
-              onClick={() => this.approveAction(job, action)}
+              onClick={() => this.giveApprovalAction(job, action, true)}
             >
               Accept
             </Button>,
-            <Button danger onClick={() => this.disprovesAction(job, action)}>
+            <Button danger onClick={() => this.giveApprovalAction(job, action, false)}>
               Decline
             </Button>,
           ]}
@@ -109,23 +109,12 @@ class AutomatorJob extends Component {
     return this.actionDetails(job, action);
   }
 
-  approveAction(job, action) {
-    job.actions[action].approval.approved = true;
+  giveApprovalAction(job, action, approve) {
+    job.actions[action].approval.approved = approve;
     job.actions[action].approval.approvedBy = this.props.api.clientId;
-    job.status = "Pending";
+    job.status = approve ? "Pending" : "Done";
     this.props.api.client
-      .put(`/automator/jobs/${job._id}?push=true`, job, { timeout: 10000 })
-      .then(() => {
-        this.props.onFetching();
-      });
-    this.setState({ job });
-  }
-  disprovesAction(job, action) {
-    job.actions[action].approval.approved = false;
-    job.actions[action].approval.approvedBy = this.props.api.clientId;
-    job.status = "Done";
-    this.props.api.client
-      .put(`/automator/jobs/${job._id}`, job, { timeout: 10000 })
+      .put(`/automator/jobs/${job._id + (approve ? "?push=true" : "")}`, job, { timeout: 10000 })
       .then(() => {
         this.props.onFetching();
       });

--- a/src/components/AutomatorService/AutomatorJob.js
+++ b/src/components/AutomatorService/AutomatorJob.js
@@ -8,12 +8,13 @@ import ProvisioningDetails from "./Details/ProvisioningDetails";
 import ShowcaseDetails from "./Details/ShowcaseDetails";
 import GtmDetails from "./Details/GtmDetails";
 import {
-  CheckCircleOutlined,
-  LoadingOutlined,
+  CheckCircleOutlined, DislikeOutlined, LikeOutlined,
+  LoadingOutlined, QuestionCircleOutlined,
   ReloadOutlined,
-  WarningOutlined,
-} from "@ant-design/icons";
+  WarningOutlined
+} from '@ant-design/icons';
 import AutomatorJobActions from "./AutomatorJobActions";
+import Meta from 'antd/es/card/Meta';
 
 const { TabPane } = Tabs;
 const { TextArea } = Input;
@@ -47,6 +48,39 @@ class AutomatorJob extends Component {
 
   renderActionPanel(action) {
     const { job } = this.state;
+    if (job.actions?.[action]?.preview && job.actions?.[action]?.approval.approved === undefined) {
+      return (
+        <Card
+        title="Preview result"
+        actions={[
+          <Button
+            danger
+            style={{borderColor: "green" , color:"green"}}
+            onClick={() => this.approveAction(job, action)}
+          >
+            Accept
+          </Button>,
+          <Button
+            danger
+            onClick={() => this.disprovesAction(job,action)}
+          >
+            Denied
+          </Button>,
+        ]}>
+          {this.actionDetails(job, action)}
+        </Card>
+      )
+    }
+    if(typeof job.actions?.[action]?.approval?.approved === 'boolean'){
+      return (
+        <Card
+          cover={this.actionDetails(job, action)}>
+          <Meta title={`${job.actions?.[action]?.approval.approved ? 'Approved' : 'Disproves'} by ${job.actions?.[action]?.approval.approvedBy}`}
+                style={{"text-align":"center"}}
+          />
+        </Card>
+      )
+    }
     if (!job.actions?.[action]?.result) {
       return <Empty />;
     }
@@ -60,17 +94,40 @@ class AutomatorJob extends Component {
         />
       );
     }
+    return this.actionDetails(job, action);
+  }
+
+  approveAction(job,action){
+    job.actions[action].approval.approved = true;
+    job.actions[action].approval.approvedBy = this.props.api.clientId;
+    job.status = 'Pending';
+    this.props.api.client.put(
+      `/automator/jobs/${job._id}?push=true`,
+      job, {timeout : 10000}
+    ).then(()=>{this.props.onFetching();});
+  }
+  disprovesAction(job,action){
+    job.actions[action].approval.approved = false
+    job.actions[action].approval.approvedBy = this.props.api.clientId
+    job.status = 'Done';
+    this.props.api.client.put(
+      `/automator/jobs/${job._id}`,
+      job,{timeout : 10000}
+    ).then(()=>{this.props.onFetching();});
+  }
+
+  actionDetails(job, action){
     switch (action) {
       case "stylesheet":
-        return <StylesheetDetails result={job.actions[action].result} />;
+        return <StylesheetDetails result={job.actions[action].result ?? job.actions[action].preview} />;
       case "scanner":
-        return <ScannerDetails result={job.actions[action].result} />;
+        return <ScannerDetails result={job.actions[action].result ?? job.actions[action].preview} />;
       case "provisioning":
-        return <ProvisioningDetails result={job.actions[action].result} />;
+        return <ProvisioningDetails result={job.actions[action].result ?? job.actions[action].preview} />;
       case "showcase":
-        return <ShowcaseDetails result={job.actions[action].result} />;
+        return <ShowcaseDetails result={job.actions[action].result ?? job.actions[action].preview} />;
       case "gtm":
-        return <GtmDetails result={job.actions[action].result} />;
+        return <GtmDetails result={job.actions[action].result ?? job.actions[action].preview} />;
       case "emailing":
         return <></>;
       default:
@@ -91,6 +148,28 @@ class AutomatorJob extends Component {
     }
 
     function getTab(action) {
+      if (job.actions?.[action]?.preview) {
+        if(job.actions?.[action]?.approval?.approved){
+          return (
+            <>
+               <LikeOutlined /> {action}
+            </>
+          );
+        }
+        // don't use ! because job.actions?.[action]?.approval?.approved can be undefined
+        if(job.actions?.[action]?.approval?.approved === false){
+          return (
+            <>
+              <DislikeOutlined /> {action}
+            </>
+          );
+        }
+        return (
+          <>
+            <QuestionCircleOutlined /> {action}
+          </>
+        );
+      }
       if (!job.actions?.[action]?.result) {
         return action;
       }

--- a/src/components/AutomatorService/AutomatorJob.js
+++ b/src/components/AutomatorService/AutomatorJob.js
@@ -8,13 +8,16 @@ import ProvisioningDetails from "./Details/ProvisioningDetails";
 import ShowcaseDetails from "./Details/ShowcaseDetails";
 import GtmDetails from "./Details/GtmDetails";
 import {
-  CheckCircleOutlined, DislikeOutlined, LikeOutlined,
-  LoadingOutlined, QuestionCircleOutlined,
+  CheckCircleOutlined,
+  DislikeOutlined,
+  LikeOutlined,
+  LoadingOutlined,
+  QuestionCircleOutlined,
   ReloadOutlined,
-  WarningOutlined
-} from '@ant-design/icons';
+  WarningOutlined,
+} from "@ant-design/icons";
 import AutomatorJobActions from "./AutomatorJobActions";
-import Meta from 'antd/es/card/Meta';
+import Meta from "antd/es/card/Meta";
 
 const { TabPane } = Tabs;
 const { TextArea } = Input;
@@ -54,42 +57,51 @@ class AutomatorJob extends Component {
           readOnly
           rows={6}
           style={{ width: "100%", fontFamily: "Monaco, monospace" }}
-          defaultValue={JSON.stringify(job.actions[action].result.error, null, 2)}
+          defaultValue={JSON.stringify(
+            job.actions[action].result.error,
+            null,
+            2
+          )}
         />
       );
     }
-    if (job.actions?.[action]?.preview && job.actions?.[action]?.approval.approved === undefined) {
+    if (
+      job.actions?.[action]?.preview &&
+      job.actions?.[action]?.approval.approved === undefined
+    ) {
       return (
         <Card
-        title="Preview result"
-        actions={[
-          <Button
-            danger
-            style={{borderColor: "green" , color:"green"}}
-            onClick={() => this.approveAction(job, action)}
-          >
-            Accept
-          </Button>,
-          <Button
-            danger
-            onClick={() => this.disprovesAction(job,action)}
-          >
-            Denied
-          </Button>,
-        ]}>
+          title="Preview result"
+          actions={[
+            <Button
+              danger
+              style={{ borderColor: "green", color: "green" }}
+              onClick={() => this.approveAction(job, action)}
+            >
+              Accept
+            </Button>,
+            <Button danger onClick={() => this.disprovesAction(job, action)}>
+              Denied
+            </Button>,
+          ]}
+        >
           {this.actionDetails(job, action)}
         </Card>
-      )
+      );
     }
-    if(typeof job.actions?.[action]?.approval?.approved === 'boolean'){
+    if (typeof job.actions?.[action]?.approval?.approved === "boolean") {
       return (
-        <Card
-          cover={this.actionDetails(job, action)}>
-          <Meta title={`${job.actions?.[action]?.approval.approved ? 'Approved' : 'Disproves'} by ${job.actions?.[action]?.approval.approvedBy}`}
-                style={{"text-align":"center"}}
+        <Card cover={this.actionDetails(job, action)}>
+          <Meta
+            title={`${
+              job.actions?.[action]?.approval.approved
+                ? "Approved"
+                : "Disproves"
+            } by ${job.actions?.[action]?.approval.approvedBy}`}
+            style={{ "text-align": "center" }}
           />
         </Card>
-      )
+      );
     }
     if (!job.actions?.[action]?.result) {
       return <Empty />;
@@ -97,39 +109,61 @@ class AutomatorJob extends Component {
     return this.actionDetails(job, action);
   }
 
-  approveAction(job,action){
+  approveAction(job, action) {
     job.actions[action].approval.approved = true;
     job.actions[action].approval.approvedBy = this.props.api.clientId;
-    job.status = 'Pending';
-    this.props.api.client.put(
-      `/automator/jobs/${job._id}?push=true`,
-      job, {timeout : 10000}
-    ).then(()=>{this.props.onFetching();});
+    job.status = "Pending";
+    this.props.api.client
+      .put(`/automator/jobs/${job._id}?push=true`, job, { timeout: 10000 })
+      .then(() => {
+        this.props.onFetching();
+      });
     this.setState({ job });
   }
-  disprovesAction(job,action){
-    job.actions[action].approval.approved = false
-    job.actions[action].approval.approvedBy = this.props.api.clientId
-    job.status = 'Done';
-    this.props.api.client.put(
-      `/automator/jobs/${job._id}`,
-      job,{timeout : 10000}
-    ).then(()=>{this.props.onFetching();});
+  disprovesAction(job, action) {
+    job.actions[action].approval.approved = false;
+    job.actions[action].approval.approvedBy = this.props.api.clientId;
+    job.status = "Done";
+    this.props.api.client
+      .put(`/automator/jobs/${job._id}`, job, { timeout: 10000 })
+      .then(() => {
+        this.props.onFetching();
+      });
     this.setState({ job });
   }
 
-  actionDetails(job, action){
+  actionDetails(job, action) {
     switch (action) {
       case "stylesheet":
-        return <StylesheetDetails result={job.actions[action].result ?? job.actions[action].preview} />;
+        return (
+          <StylesheetDetails
+            result={job.actions[action].result ?? job.actions[action].preview}
+          />
+        );
       case "scanner":
-        return <ScannerDetails result={job.actions[action].result ?? job.actions[action].preview} />;
+        return (
+          <ScannerDetails
+            result={job.actions[action].result ?? job.actions[action].preview}
+          />
+        );
       case "provisioning":
-        return <ProvisioningDetails result={job.actions[action].result ?? job.actions[action].preview} />;
+        return (
+          <ProvisioningDetails
+            result={job.actions[action].result ?? job.actions[action].preview}
+          />
+        );
       case "showcase":
-        return <ShowcaseDetails result={job.actions[action].result ?? job.actions[action].preview} />;
+        return (
+          <ShowcaseDetails
+            result={job.actions[action].result ?? job.actions[action].preview}
+          />
+        );
       case "gtm":
-        return <GtmDetails result={job.actions[action].result ?? job.actions[action].preview} />;
+        return (
+          <GtmDetails
+            result={job.actions[action].result ?? job.actions[action].preview}
+          />
+        );
       case "emailing":
         return <></>;
       default:
@@ -158,16 +192,16 @@ class AutomatorJob extends Component {
         );
       }
 
-      if(job.actions?.[action]?.approval?.approved){
+      if (job.actions?.[action]?.approval?.approved) {
         return (
           <>
-             <LikeOutlined /> {action}
+            <LikeOutlined /> {action}
           </>
         );
       }
 
       // don't use "!" because job.actions?.[action]?.approval?.approved can be undefined
-      if(job.actions?.[action]?.approval?.approved === false){
+      if (job.actions?.[action]?.approval?.approved === false) {
         return (
           <>
             <DislikeOutlined /> {action}
@@ -175,7 +209,7 @@ class AutomatorJob extends Component {
         );
       }
 
-      if(job.actions?.[action]?.preview) {
+      if (job.actions?.[action]?.preview) {
         return (
           <>
             <QuestionCircleOutlined /> {action}

--- a/src/components/AutomatorService/AutomatorJob.js
+++ b/src/components/AutomatorService/AutomatorJob.js
@@ -96,7 +96,7 @@ class AutomatorJob extends Component {
             title={`${
               job.actions?.[action]?.approval.approved
                 ? "Approved"
-                : "Disproves"
+                : "Disapproved"
             } by ${job.actions?.[action]?.approval.approvedBy}`}
             style={{ "text-align": "center" }}
           />

--- a/src/components/AutomatorService/AutomatorJob.js
+++ b/src/components/AutomatorService/AutomatorJob.js
@@ -48,6 +48,16 @@ class AutomatorJob extends Component {
 
   renderActionPanel(action) {
     const { job } = this.state;
+    if (job.actions?.[action]?.result?.error) {
+      return (
+        <TextArea
+          readOnly
+          rows={6}
+          style={{ width: "100%", fontFamily: "Monaco, monospace" }}
+          defaultValue={JSON.stringify(job.actions[action].result.error, null, 2)}
+        />
+      );
+    }
     if (job.actions?.[action]?.preview && job.actions?.[action]?.approval.approved === undefined) {
       return (
         <Card
@@ -84,16 +94,6 @@ class AutomatorJob extends Component {
     if (!job.actions?.[action]?.result) {
       return <Empty />;
     }
-    if (job.actions[action].result.error) {
-      return (
-        <TextArea
-          readOnly
-          rows={6}
-          style={{ width: "100%", fontFamily: "Monaco, monospace" }}
-          defaultValue={JSON.stringify(job.actions[action].result.error, null, 2)}
-        />
-      );
-    }
     return this.actionDetails(job, action);
   }
 
@@ -105,6 +105,7 @@ class AutomatorJob extends Component {
       `/automator/jobs/${job._id}?push=true`,
       job, {timeout : 10000}
     ).then(()=>{this.props.onFetching();});
+    this.setState({ job });
   }
   disprovesAction(job,action){
     job.actions[action].approval.approved = false
@@ -114,6 +115,7 @@ class AutomatorJob extends Component {
       `/automator/jobs/${job._id}`,
       job,{timeout : 10000}
     ).then(()=>{this.props.onFetching();});
+    this.setState({ job });
   }
 
   actionDetails(job, action){
@@ -148,37 +150,41 @@ class AutomatorJob extends Component {
     }
 
     function getTab(action) {
-      if (job.actions?.[action]?.preview) {
-        if(job.actions?.[action]?.approval?.approved){
-          return (
-            <>
-               <LikeOutlined /> {action}
-            </>
-          );
-        }
-        // don't use ! because job.actions?.[action]?.approval?.approved can be undefined
-        if(job.actions?.[action]?.approval?.approved === false){
-          return (
-            <>
-              <DislikeOutlined /> {action}
-            </>
-          );
-        }
+      if (job.actions?.[action]?.result?.error) {
+        return (
+          <>
+            <WarningOutlined /> {action}
+          </>
+        );
+      }
+
+      if(job.actions?.[action]?.approval?.approved){
+        return (
+          <>
+             <LikeOutlined /> {action}
+          </>
+        );
+      }
+
+      // don't use "!" because job.actions?.[action]?.approval?.approved can be undefined
+      if(job.actions?.[action]?.approval?.approved === false){
+        return (
+          <>
+            <DislikeOutlined /> {action}
+          </>
+        );
+      }
+
+      if(job.actions?.[action]?.preview) {
         return (
           <>
             <QuestionCircleOutlined /> {action}
           </>
         );
       }
+
       if (!job.actions?.[action]?.result) {
         return action;
-      }
-      if (job.actions[action]?.result?.error) {
-        return (
-          <>
-            <WarningOutlined /> {action}
-          </>
-        );
       }
 
       return (

--- a/src/components/AutomatorService/AutomatorJob.js
+++ b/src/components/AutomatorService/AutomatorJob.js
@@ -81,7 +81,7 @@ class AutomatorJob extends Component {
               Accept
             </Button>,
             <Button danger onClick={() => this.disprovesAction(job, action)}>
-              Denied
+              Decline
             </Button>,
           ]}
         >

--- a/src/components/AutomatorService/AutomatorJobActions.js
+++ b/src/components/AutomatorService/AutomatorJobActions.js
@@ -32,7 +32,7 @@ export const actionNames = {
   provisioning: "provisioning",
   showcase: "showcase",
   gtm: "gtm",
-  emailing: "emailing"
+  emailing: "emailing",
 };
 
 export default actionsMap;

--- a/src/components/AutomatorService/AutomatorJobForm.js
+++ b/src/components/AutomatorService/AutomatorJobForm.js
@@ -50,6 +50,18 @@ function AutomatorJobForm({ onFinish, api }) {
     );
   }
 
+  function approvalOption(action) {
+    return (<Form.Item
+      name={["actions", action, "approval","email"]}
+      initialValue = {false}
+      label="Requires your approval"
+    >
+      <Switch />
+    </Form.Item>
+    )
+
+  }
+
   return (
     <Form
       labelAlign="right"
@@ -106,19 +118,22 @@ function AutomatorJobForm({ onFinish, api }) {
         </Form.Item>
         <Tabs type="card">
           <TabPane tab={getActionTab("scanner")} key="scanner">
+            {
+              approvalOption("scanner")
+            }
             <Form.Item
               name={["actions", "scanner", "maxTabs"]}
               label="Max Tabs"
               initialValue={4}
             >
-              <InputNumber min={1} max={10} />
+              <InputNumber min={1} max={20} />
             </Form.Item>
             <Form.Item
               name={["actions", "scanner", "maxPages"]}
               label="Max Pages"
               initialValue={10}
             >
-              <InputNumber min={1} max={1000} />
+              <InputNumber min={0} max={1000} />
             </Form.Item>
             <Form.Item
               name={["actions", "scanner", "testCMP"]}
@@ -138,9 +153,15 @@ function AutomatorJobForm({ onFinish, api }) {
             </Form.Item>
           </TabPane>
           <TabPane tab={getActionTab("stylesheet")} key="stylesheet">
+            {
+              approvalOption("stylesheet")
+            }
             <Empty description="There are no option available for this action" />
           </TabPane>
           <TabPane tab={getActionTab("provisioning")} key="provisioning">
+            {
+              approvalOption("provisioning")
+            }
             <Form.Item
               name={["actions", "provisioning", "database"]}
               initialValue="test"
@@ -193,6 +214,9 @@ function AutomatorJobForm({ onFinish, api }) {
             />
           </TabPane>
           <TabPane tab={getActionTab("showcase")} key="showcase">
+            {
+              approvalOption("showcase")
+            }
             <Form.Item
               name={["actions", "showcase", "publishProject"]}
               initialValue={true}
@@ -321,6 +345,9 @@ function AutomatorJobForm({ onFinish, api }) {
             </Form.List>
           </TabPane>
           <TabPane tab={getActionTab("gtm")} key="gtm">
+            {
+              approvalOption("gtm")
+            }
             <Empty description="There are no option available for this action" />
           </TabPane>
           <TabPane tab={getActionTab("emailing")} key="emailing">

--- a/src/components/AutomatorService/AutomatorJobForm.js
+++ b/src/components/AutomatorService/AutomatorJobForm.js
@@ -51,15 +51,15 @@ function AutomatorJobForm({ onFinish, api }) {
   }
 
   function approvalOption(action) {
-    return (<Form.Item
-      name={["actions", action, "approval","email"]}
-      initialValue = {false}
-      label="Requires your approval"
-    >
-      <Switch />
-    </Form.Item>
-    )
-
+    return (
+      <Form.Item
+        name={["actions", action, "approval", "email"]}
+        initialValue={false}
+        label="Requires your approval"
+      >
+        <Switch />
+      </Form.Item>
+    );
   }
 
   return (
@@ -118,9 +118,7 @@ function AutomatorJobForm({ onFinish, api }) {
         </Form.Item>
         <Tabs type="card">
           <TabPane tab={getActionTab("scanner")} key="scanner">
-            {
-              approvalOption("scanner")
-            }
+            {approvalOption("scanner")}
             <Form.Item
               name={["actions", "scanner", "maxTabs"]}
               label="Max Tabs"
@@ -153,15 +151,11 @@ function AutomatorJobForm({ onFinish, api }) {
             </Form.Item>
           </TabPane>
           <TabPane tab={getActionTab("stylesheet")} key="stylesheet">
-            {
-              approvalOption("stylesheet")
-            }
+            {approvalOption("stylesheet")}
             <Empty description="There are no option available for this action" />
           </TabPane>
           <TabPane tab={getActionTab("provisioning")} key="provisioning">
-            {
-              approvalOption("provisioning")
-            }
+            {approvalOption("provisioning")}
             <Form.Item
               name={["actions", "provisioning", "database"]}
               initialValue="test"
@@ -214,9 +208,7 @@ function AutomatorJobForm({ onFinish, api }) {
             />
           </TabPane>
           <TabPane tab={getActionTab("showcase")} key="showcase">
-            {
-              approvalOption("showcase")
-            }
+            {approvalOption("showcase")}
             <Form.Item
               name={["actions", "showcase", "publishProject"]}
               initialValue={true}
@@ -345,9 +337,7 @@ function AutomatorJobForm({ onFinish, api }) {
             </Form.List>
           </TabPane>
           <TabPane tab={getActionTab("gtm")} key="gtm">
-            {
-              approvalOption("gtm")
-            }
+            {approvalOption("gtm")}
             <Empty description="There are no option available for this action" />
           </TabPane>
           <TabPane tab={getActionTab("emailing")} key="emailing">

--- a/src/components/AutomatorService/AutomatorService.js
+++ b/src/components/AutomatorService/AutomatorService.js
@@ -43,7 +43,7 @@ function BulkJobCreationModal({ api, services, ...props }) {
 class AutomatorService extends Component {
   constructor(props) {
     super(props);
-    this.refreshJobs = this.refreshJobs.bind(this);
+    this.fetchData = this.fetchData.bind(this);
   }
   state = {
     bulkJobCreationModalOpen: false,
@@ -88,8 +88,7 @@ class AutomatorService extends Component {
                   color = "red";
                 } else if (value[action].result) {
                   color = "green";
-                }
-                if (value[action].preview) {
+                } else if (value[action].preview) {
                   // value[action].approval.approved can be undefine
                   if(value[action].approval?.approved === false){
                     color = "lightgrey"
@@ -249,11 +248,6 @@ class AutomatorService extends Component {
     }
   }
 
-  async refreshJobs(){
-    console.log("fetching in props");
-    await this.fetchData();
-  }
-
   render(){
     const { services, service, api } = this.props;
     const {
@@ -285,7 +279,7 @@ class AutomatorService extends Component {
           <Routes>
             <Route
               path={`jobs/:id`}
-              element={<AutomatorJob onFetching={() => {this.refreshJobs()}} service={service} />}
+              element={<AutomatorJob onFetching={() => {this.fetchData()}} service={service} />}
             />
           </Routes>
           <Card

--- a/src/components/AutomatorService/AutomatorService.js
+++ b/src/components/AutomatorService/AutomatorService.js
@@ -90,9 +90,9 @@ class AutomatorService extends Component {
                   color = "green";
                 } else if (value[action].preview) {
                   // value[action].approval.approved can be undefine
-                  if(value[action].approval?.approved === false){
-                    color = "lightgrey"
-                  } else if(!value[action].approval?.approved) {
+                  if (value[action].approval?.approved === false) {
+                    color = "lightgrey";
+                  } else if (!value[action].approval?.approved) {
                     color = "blue";
                   }
                 }
@@ -148,16 +148,17 @@ class AutomatorService extends Component {
       actions: {},
       projectId: job.projectId,
     };
-      if (!new RegExp("^[a-f\\d]{24}$").test(updatedValues.projectId)) {
-        delete updatedValues.projectId;
-      }
+    if (!new RegExp("^[a-f\\d]{24}$").test(updatedValues.projectId)) {
+      delete updatedValues.projectId;
+    }
     for (const [actionName, value] of Object.entries(job.actions)) {
       if (value.active) {
         updatedValues.actions[actionName] = value;
-        if(value.approval.email){
-          updatedValues.actions[actionName].approval.email = this.props.api.clientEmail
+        if (value.approval.email) {
+          updatedValues.actions[actionName].approval.email =
+            this.props.api.clientEmail;
         } else {
-          delete updatedValues.actions[actionName].approval
+          delete updatedValues.actions[actionName].approval;
         }
       }
     }
@@ -248,7 +249,7 @@ class AutomatorService extends Component {
     }
   }
 
-  render(){
+  render() {
     const { services, service, api } = this.props;
     const {
       jobs,
@@ -279,7 +280,14 @@ class AutomatorService extends Component {
           <Routes>
             <Route
               path={`jobs/:id`}
-              element={<AutomatorJob onFetching={() => {this.fetchData()}} service={service} />}
+              element={
+                <AutomatorJob
+                  onFetching={() => {
+                    this.fetchData();
+                  }}
+                  service={service}
+                />
+              }
             />
           </Routes>
           <Card


### PR DESCRIPTION
In this feature, we allow front users to be able to interact with a job waiting for approval.

What was done :

1.  Add two data in the api client : `clientEmail` `clientId` which comes from the connected client

2. Be able to give its approval, with a preview of the future result : 

> ⚠️ ⚠️  `Denied` has been changed by `Decline` 😄  ⚠️ ⚠️ 

<img width="1122" alt="Capture d’écran 2022-10-11 à 17 27 41" src="https://user-images.githubusercontent.com/60391768/195134540-74272c10-745e-46e4-9979-9480227e4b5e.png">

4. Have an approval history

<img width="1280" alt="Capture d’écran 2022-10-11 à 17 48 48" src="https://user-images.githubusercontent.com/60391768/195139481-4d443875-daab-44ba-8557-d942b28251d6.png">

++ Errors generated by the automator are correctly displayed and managed by the front
++ Tested locale, can go into production without disturbing the function of existing jobs
++ Prettier used
