### PR TITLE
Dev 2119 feat/restart button

### DIFF
--- a/src/components/AutomatorService/AutomatorService.js
+++ b/src/components/AutomatorService/AutomatorService.js
@@ -124,7 +124,6 @@ class AutomatorService extends Component {
                 onClick={() => this.deleteJob(job._id)}
               />
             )}
-
             {(job.status === 'Done' || job.status === 'Error') ? this.state.jobsToRestart.includes(job._id) ? (
               <Button disabled icon={<LoadingOutlined />} />
             ) : (
@@ -180,7 +179,6 @@ class AutomatorService extends Component {
       jobsDeleting: this.state.jobsDeleting.filter((jobId) => jobId !== id),
       jobs: this.state.jobs.filter((job) => job._id !== id),
     });
-
     if (this.state.jobsDeleting.length === 0) {
       await this.fetchData();
     }

--- a/src/components/AutomatorService/AutomatorService.js
+++ b/src/components/AutomatorService/AutomatorService.js
@@ -18,8 +18,8 @@ import {
   DeleteOutlined,
   EyeOutlined,
   LoadingOutlined,
-  ReloadOutlined,
-} from "@ant-design/icons";
+  ReloadOutlined, UndoOutlined
+} from '@ant-design/icons';
 import AutomatorJobForm from "./AutomatorJobForm";
 import actions from "./AutomatorJobActions";
 import BulkJobCreationForm from "./BulkJobCreationForm";
@@ -129,7 +129,7 @@ class AutomatorService extends Component {
               <Button disabled icon={<LoadingOutlined />} />
             ) : (
               <Button
-                icon={<ReloadOutlined />}
+                icon={<UndoOutlined />}
                 onClick={() => this.restartJob(job)}
               />
             ) : ''}


### PR DESCRIPTION
In this feature, we add a button to restart a job in a `done` or `error` status

Of course, it will work like the delete button, it will fetch while the job is restarting on the back-end api.

<img width="1163" alt="Capture d’écran 2022-11-04 à 16 26 03" src="https://user-images.githubusercontent.com/60391768/200020174-29f868ee-ddb8-43fb-8992-aa5b6b32c7c1.png">
