### PR TITLE
DEV-2915-improvement/add-sendgrid-output-option

### DIFF
--- a/src/components/AutomatorService/Forms/EmailingForm.js
+++ b/src/components/AutomatorService/Forms/EmailingForm.js
@@ -4,7 +4,10 @@ import { useEffect, useState } from "react";
 export default function EmailingForm({ api }) {
   const [campaigns, setCampaigns] = useState([]);
   const [emailCheck, setEmailCheck] = useState(undefined);
+  const [groups, setGroups] = useState([]);
   const [selectedCampaign, setSelectedCampaign] = useState(undefined);
+  const [, setSelectedGroup] = useState(undefined);
+  const [, setSender] = useState(undefined);
   const [provider, setProvider] = useState("");
   const [email, setEmail] = useState("");
 
@@ -16,6 +19,9 @@ export default function EmailingForm({ api }) {
     api.client
       .get(`/automator/emailing/${provider}/campaigns`)
       .then((response) => setCampaigns(response.data));
+    api.client
+      .get(`/automator/emailing/${provider}/groups`)
+      .then((response) => setGroups(response.data));
   }, [provider, api.client]);
 
   useEffect(() => {
@@ -65,9 +71,28 @@ export default function EmailingForm({ api }) {
       >
         <Input onBlur={(event) => setEmail(event.target.value)} />
       </Form.Item>
+      <Form.Item name={["actions", "emailing", "sender"]} label="Sender">
+        <Input
+          placeHolder={"Automator 🍪 <noreply@axeptio.eu>"}
+          onBlur={(event) => setSender(event.target.value)}
+        />
+      </Form.Item>
       <Form.Item name={["actions", "emailing", "campaign"]} label="Campaign">
         <Select onChange={(value) => setSelectedCampaign(value)}>
           {campaigns.map((c) => (
+            <Select.Option value={c.id} key={c.id}>
+              {c.name}
+            </Select.Option>
+          ))}
+        </Select>
+      </Form.Item>
+      <Form.Item
+        name={["actions", "emailing", "groupId"]}
+        label="Unsubscription Group"
+        help={"To choose in the case of a prospection/newsletter..."}
+      >
+        <Select onChange={(value) => setSelectedGroup(value)}>
+          {groups.map((c) => (
             <Select.Option value={c.id} key={c.id}>
               {c.name}
             </Select.Option>


### PR DESCRIPTION
DEV-2915

in this pr, we make sure to allow the user to choose a group to attach the prospecting mail.

By the way, we also add the possibility to add a sender

Preview:
<img width="1118" alt="Capture d’écran 2023-02-23 à 10 00 38" src="https://user-images.githubusercontent.com/60391768/220862405-31827b69-28bf-40da-bdbb-10deaee51316.png">

<img width="1124" alt="Capture d’écran 2023-02-23 à 10 05 00" src="https://user-images.githubusercontent.com/60391768/220863285-5b326581-7f27-450a-9a22-e3e3d2ff0b8d.png">

