### PR TITLE
Dev 3050 fix/listing ressource

### DIFF
--- a/src/components/DocsService/ResourceForm.js
+++ b/src/components/DocsService/ResourceForm.js
@@ -142,7 +142,7 @@ class ResourceForm extends Component {
       } else if (customWidgets[schema["ui:widget"]]) {
         uiSchema["ui:widget"] = customWidgets[schema["ui:widget"]];
       } else if (schema["ui:relation"]) {
-        uiSchema["ui:field"] = generateRelationField(schema["ui:relation"]);
+        uiSchema["ui:field"] = generateRelationField({...schema["ui:relation"], perPage: 0});
       } else if (schema.items) {
         uiSchema.items = {};
         parseSchema(schema.items, uiSchema.items);

--- a/src/components/RelationField/RelationField.js
+++ b/src/components/RelationField/RelationField.js
@@ -8,18 +8,18 @@ import { LoadingOutlined, PlusOutlined } from "@ant-design/icons";
  * @todo disable item creation with a schema property
  * @todo implement server-side filtering
  *
- * @param {object} properties
+ * @param {*&{perPage: number}} properties
  * @param {string} properties.resource
  * @param {string} properties.service
  * @returns {React.Component}
  */
 function generateRelationField(properties) {
-  const { resource, service, labelIndex = "name" } = properties;
+  const { resource, service, labelIndex = "name", perPage } = properties;
 
   class RelationField extends Component {
     state = {
       items: [],
-      perPage: 100,
+      perPage: perPage ?? 100,
       page: 1,
       totalCount: 0,
       newItemData: {},


### PR DESCRIPTION
In this Pr, we fix some problèmes with listing system:

- error with pagination system (One page behind the one requested + sends constant two requests)
- error with sorting system (doesn't work before this fix)
- add a false boolean icon with listing fields
- fix error with relations fields in ressources form (add an option perPage)