### PR TITLE
feat: allow both use of old ($) and new (__) compilation sign (DEV-3309)

### DIFF
--- a/src/components/AutomatorService/Details/ScannerDetails.js
+++ b/src/components/AutomatorService/Details/ScannerDetails.js
@@ -164,7 +164,7 @@ class ScannerDetails extends Component {
       dataIndex: "title",
       key: "title",
       render: (value) => {
-        return value ? value.$lang?.en ?? value : "";
+        return value ? (value.$lang?.en || value.__lang?.en) ?? value : "";
       },
     },
     {
@@ -200,13 +200,18 @@ class ScannerDetails extends Component {
         if (typeof value === "object") {
           return (
             <Space>
-              {Object.keys(value.$lang || {}).map((language) => {
-                return (
-                  <a key={language} href={value.$lang[language]}>
-                    {language}
-                  </a>
-                );
-              })}
+              {Object.keys(value.__lang || value.$lang || {}).map(
+                (language) => {
+                  return (
+                    <a
+                      key={language}
+                      href={value.__lang?.[language] || value.$lang[language]}
+                    >
+                      {language}
+                    </a>
+                  );
+                }
+              )}
             </Space>
           );
         }

--- a/src/components/DocsService/ResourceListing.js
+++ b/src/components/DocsService/ResourceListing.js
@@ -147,9 +147,13 @@ class ResourceListing extends Component {
         return filters[key]?.length > 0;
       })
       .forEach((key) => {
-        const propertyPath = filters[key][0].isLocalizedString
-          ? `${key}.$lang.en`
-          : key;
+        let propertyPath = key;
+        if (filters[key][0].isLocalizedString) {
+          propertyPath = filters[key][0].__lang
+            ? `${key}.__lang.en`
+            : `${key}.$lang.en`;
+        }
+
         params.append(
           `${propertyPath}${filters[key][0].operator}`,
           filters[key][0].value
@@ -232,8 +236,10 @@ class ResourceListing extends Component {
         case "boolean":
           return value ? <CheckOutlined /> : <CloseOutlined />;
         case "object":
-          if (value?.$lang) {
-            return this.renderStringInCell(value.$lang[language]);
+          if (value?.__lang || value?.$lang) {
+            return this.renderStringInCell(
+              value.__lang?.[language] || value.$lang?.[language]
+            );
           }
           if (value?.url && value?.detectedMimeType) {
             if (value.detectedMimeType.includes("image")) {

--- a/src/components/LocalizedText/LocalizedText.js
+++ b/src/components/LocalizedText/LocalizedText.js
@@ -9,7 +9,10 @@ export function cleanLocalizedValue(value) {
   }
 
   if (typeof value === "object" && value !== null) {
-    if (value.$lang && Object.keys(value.$lang).length === 0) {
+    if (
+      (value.__lang && Object.keys(value.__lang).length === 0) ||
+      (value.$lang && Object.keys(value.$lang).length === 0)
+    ) {
       return undefined;
     }
     const result = {};
@@ -27,7 +30,8 @@ export function cleanLocalizedValue(value) {
 
 export default function LocalizedText({ formData, schema, name, onChange }) {
   const [selectedLanguage, setSelectedLanguage] = useState("en");
-  const value = formData?.$lang || { [selectedLanguage]: "" };
+  const value = formData?.__lang ||
+    formData?.$lang || { [selectedLanguage]: "" };
   const fieldValue = value[selectedLanguage];
   const InputComponent = schema["ui:multiline"] ? TextArea : Input;
   const [selectSpan, inputSpan] = schema["ui:multiline"] ? [24, 24] : [8, 16];
@@ -62,7 +66,7 @@ export default function LocalizedText({ formData, schema, name, onChange }) {
             rows={6}
             onChange={(event) => {
               const newValue = {
-                $lang: sanitizeValue({
+                __lang: sanitizeValue({
                   ...value,
                   [selectedLanguage]: event.target.value,
                 }),

--- a/src/components/Playground/Playground.js
+++ b/src/components/Playground/Playground.js
@@ -65,8 +65,18 @@ const schema = {
             type: "string",
           },
         },
+        __lang: {
+          title: "Language",
+          type: "object",
+          patternProperties: {
+            "^[a-z]{2}$": { type: "string" },
+          },
+          additionalProperties: {
+            type: "string",
+          },
+        },
       },
-      required: ["$lang"],
+      anyOf: [{ required: ["$lang"] }, { required: ["__lang"] }],
     },
   },
 };

--- a/src/components/Playground/Playground.js
+++ b/src/components/Playground/Playground.js
@@ -55,16 +55,6 @@ const schema = {
       isLocalizedString: true,
       type: "object",
       properties: {
-        $lang: {
-          title: "Language",
-          type: "object",
-          patternProperties: {
-            "^[a-z]{2}$": { type: "string" },
-          },
-          additionalProperties: {
-            type: "string",
-          },
-        },
         __lang: {
           title: "Language",
           type: "object",
@@ -76,7 +66,7 @@ const schema = {
           },
         },
       },
-      anyOf: [{ required: ["$lang"] }, { required: ["__lang"] }],
+      required: ["__lang"],
     },
   },
 };


### PR DESCRIPTION
allows use of both old `$`  and new `__` compilation sign

TODO: 

- [x] caas-api
- [x] caas-styleguide
- [x] automator
- [x] campsi-admin