### PR TITLE
Add functionality to download CSV for specific bulk scan tags

### DIFF
--- a/src/components/AutomatorService/AutomatorService.js
+++ b/src/components/AutomatorService/AutomatorService.js
@@ -63,6 +63,7 @@ class AutomatorService extends Component {
     activeActions: [],
     jobs: [],
     isFetching: false,
+    selectedTags: [],
     columns: [
       {
         title: 'Created At',
@@ -298,7 +299,7 @@ class AutomatorService extends Component {
 
   async fetchTags() {
     const { api, service } = this.props;
-    const response = await api.client.get(`${service.name}/tags`);
+    const response = await api.client.get(`${service.name}/tags`, { timeout: 60000 });
     await this.setStateAsync({
       tags: response.data.map(obj => {
         return { label: obj.tag, value: obj.tag };

--- a/src/components/AutomatorService/automatorHelpers.js
+++ b/src/components/AutomatorService/automatorHelpers.js
@@ -31,18 +31,18 @@ export function convertJobsToCSVString(jsonData) {
   ];
 
   const rows = jsonData.map(item => [
-    item.status || '',
-    item.params?.domain || '',
-    'CMP custom', // Assuming static value for CMP Found
-    item.actions?.scanner?.result?.nbVendorsFound || 0,
-    item.actions?.scanner?.result?.vendorsWellConfigured || 0,
-    item.actions?.scanner?.result?.vendorsTriggeredWithoutConsent || 0,
-    'https://example.com/en.PDF', // Placeholder for PDF URL EN
-    'https://example.com/fr.PDF', // Placeholder for PDF URL FR
-    item.actions?.scanner?.result?.vendorsTriggeredWithoutConsent || 0,
-    item.actions?.scanner?.result?.vendorsExemptOfConsent || 0,
-    item.actions?.showcase?.result?.media?.[0]?.url || '',
-    item.actions?.showcase?.result?.media?.[1]?.url || ''
+    item.status,
+    item.params?.domain,
+    item.actions?.scanner?.result?.CMP,
+    item.actions?.scanner?.result?.nbVendorsFound,
+    item.actions?.scanner?.result?.vendorsWellConfigured,
+    item.actions?.scanner?.result?.vendorsTriggeredWithoutConsent,
+    item.actions?.scanner?.result?.pdfURLs?.en,
+    item.actions?.scanner?.result?.pdfURLs?.fr,
+    item.actions?.scanner?.result?.vendorsTriggeredWithoutConsent,
+    item.actions?.scanner?.result?.vendorsExemptOfConsent,
+    item.actions?.showcase?.result?.media?.[0]?.url,
+    item.actions?.showcase?.result?.media?.[1]?.url
   ]);
 
   return headers.join(',') + '\n' + rows.map(row => row.join(',')).join('\n');

--- a/src/components/CSVtools/utils.js
+++ b/src/components/CSVtools/utils.js
@@ -1,5 +1,4 @@
 export const downloadCSV = (fileName, data) => {
-  console.log(data);
   const csvData = new Blob([data], { type: 'text/csv' });
   const csvURL = URL.createObjectURL(csvData);
   const link = document.createElement('a');


### PR DESCRIPTION
- Introduce `selectedTags` state to manage user-selected tags.
- Update API call to fetch tags with a longer timeout.
- Refactor CSV generation logic to include new data structure.
- Remove debug logging in CSV download utility.