### PR TITLE
Add consent mode V2 vendor check and update CSV download logic

### DIFF
--- a/src/components/AutomatorService/automatorHelpers.js
+++ b/src/components/AutomatorService/automatorHelpers.js
@@ -1,6 +1,7 @@
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import duration from 'dayjs/plugin/duration';
+import { isConsentModeV2Vendor } from '../../utils/comoV2';
 
 dayjs.extend(duration);
 dayjs.extend(relativeTime);
@@ -22,6 +23,7 @@ export function convertJobsToCSVString(jsonData) {
     'Vendors',
     'Vendors Well Configured',
     'Vendors Bad Configured',
+    'is ComoV2 Required',
     'pdfurlEN',
     'pdfurlFR',
     'Vendors Triggered Without Consent',
@@ -36,7 +38,9 @@ export function convertJobsToCSVString(jsonData) {
     item.actions?.scanner?.result?.CMP,
     item.actions?.scanner?.result?.nbVendorsFound,
     item.actions?.scanner?.result?.vendorsWellConfigured,
-    item.actions?.scanner?.result?.vendorsTriggeredWithoutConsent,
+    parseInt(item.actions?.scanner?.result?.nbVendorsFound - item.actions?.scanner?.result?.vendorsWellConfigured) ||
+      (item.actions?.scanner?.result?.CMP ? 0 : ''),
+    item.actions?.scanner?.result?.knownVendors.some(vendor => isConsentModeV2Vendor(vendor)),
     item.actions?.scanner?.result?.pdfURLs?.en,
     item.actions?.scanner?.result?.pdfURLs?.fr,
     item.actions?.scanner?.result?.vendorsTriggeredWithoutConsent,

--- a/src/utils/comoV2.js
+++ b/src/utils/comoV2.js
@@ -1,0 +1,9 @@
+/**
+ * Tells if a vendor needs consent mode v2
+ * @param vendor
+ * @returns {boolean|boolean}
+ */
+export async function isConsentModeV2Vendor(vendor) {
+  const name = vendor.name.toLowerCase();
+  return name.includes('google') && (name.includes('ads') || name.includes('advertising') || name.includes('analytic'));
+}


### PR DESCRIPTION
- Introduce `isConsentModeV2Vendor` function to determine if a vendor requires consent mode V2.
- Update CSV export in `automatorHelpers.js` to include a new column for consent mode V2 requirement status.
- Modify existing vendor handling logic to support the new consent mode requirements.